### PR TITLE
reference points to correct bracket

### DIFF
--- a/src/MarchMadnessGUI.java
+++ b/src/MarchMadnessGUI.java
@@ -128,7 +128,7 @@ public class MarchMadnessGUI extends Application {
                 playerBrackets.add(tmpPlayerBracket);
                 tmpPlayerBracket.setPassword(playerPass);
 
-                playerMap.put(name, emptyBracket);
+                playerMap.put(name, tmpPlayerBracket);
             }
 
             //            for ( Bracket bracket : playerBrackets) {


### PR DESCRIPTION
Found that the login was not accepting a stored user's password due to the reference pointing to the incorrect bracket.